### PR TITLE
Fixes minor linting issues

### DIFF
--- a/lib/plugins/verify/index.js
+++ b/lib/plugins/verify/index.js
@@ -129,9 +129,10 @@ async function verify(server, options) {
           'error validating with DeviceCheck'
         )
 
-        const message = err.message === 'Invalid timestamp'
-          ? 'Invalid timestamp'
-          : 'Invalid verification'
+        const message =
+          err.message === 'Invalid timestamp'
+            ? 'Invalid timestamp'
+            : 'Invalid verification'
 
         throw new BadRequest(message)
       }

--- a/lib/routes/metrics/schema.js
+++ b/lib/routes/metrics/schema.js
@@ -19,6 +19,7 @@ const event = options => ({
       'version',
       S.string()
         .pattern(
+          // eslint-disable-next-line no-useless-escape
           /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-\.]((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
         )
         .required()


### PR DESCRIPTION
In lib/routes/metrics/schema.js I've marked the lint warning as ignorable because the line seems like a fairly complex regex and I'm not keen to start messing with escape characters in it.