### PR TITLE
Do not call process.exit from within the async function

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -29,11 +29,13 @@ async function migrateSchema() {
       )
     }
 
-    console.log('Migration done')
-    process.exit(0)
+    console.log('Migration done.')
+
+    // Likely unnecessary, but just to be thorough...
+    process.exitCode = 0
   } catch (error) {
     console.error(error)
-    process.exit(1)
+    process.exitCode = 1
   }
 }
 

--- a/lib/migrate.test.js
+++ b/lib/migrate.test.js
@@ -6,16 +6,16 @@ jest.mock('postgrator')
 describe('migrate', () => {
   it('performs migrations', async () => {
     const mockMigrate = jest.fn().mockResolvedValue([])
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
     const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {})
 
     Postgrator.mockImplementation(() => ({ migrate: mockMigrate }))
 
     await migrateSchema()
 
+    expect(process.exitCode).toEqual(0)
+
     expect(mockMigrate).toHaveBeenCalledTimes(1)
     expect(mockLog).toHaveBeenCalledTimes(2)
-    expect(mockExit).toHaveBeenCalledWith(0)
   })
 
   it('logs and exits on error', async () => {
@@ -23,15 +23,15 @@ describe('migrate', () => {
       throw new Error()
     })
 
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
     const mockError = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     Postgrator.mockImplementation(() => ({ migrate: mockMigrate }))
 
     await migrateSchema()
 
+    expect(process.exitCode).toEqual(1)
+
     expect(mockMigrate).toHaveBeenCalledTimes(1)
     expect(mockError).toHaveBeenCalledTimes(1)
-    expect(mockExit).toHaveBeenCalledWith(1)
   })
 })


### PR DESCRIPTION
Sets up a proper catch handler for the `migrateSchema()` call that
explicitly sets the `process.exitCode` rather than calling
`process.exit()`

Fixes: https://github.com/covidgreen/covid-green-backend-api/issues/10