### PR TITLE
Pulls process.exit functionality outside of the migrate function 

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -30,15 +30,17 @@ async function migrateSchema() {
     }
 
     console.log('Migration done')
-    process.exit(0)
   } catch (error) {
     console.error(error)
-    process.exit(1)
   }
 }
 
 if (require.main === module) {
-  migrateSchema()
+  migrateSchema().then(() => {
+    process.exit(0);
+  }).catch(() => {
+    process.exit(1);
+  });
 }
 
 module.exports = { getPostgratorInstance, migrateSchema }


### PR DESCRIPTION
This is done so that migrate can be used elsewhere outside of the context of being directly called.

See https://github.com/covidgreen/covid-green-backend-api/issues/10

