### PR TITLE
Adds support for optional callback rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ All the endpoints in this service use varied sets of configuration settings and 
 | `CALLBACK_QUEUE_URL` | `callback_url` | ?? |
 | `ASSETS_BUCKET` | `s3_assets_bucket` | ?? |
 | `CALLBACK_RATE_LIMIT_SECS` | `security_callback_rate_limit_secs` | # of seconds required before a user can request another callback |
+| `CALLBACK_RATE_LIMIT_REQUEST_COUNT` | `security_callback_rate_limit_request_count` | # of callback requests allowed before rate limit goes into effect |
 
 #### Secret Settings
 

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -63,6 +63,7 @@ describe('configuration', () => {
     const TOKEN_LIFETIME_MINS = faker.random.number()
     const UPLOAD_TOKEN_LIFETIME_MINS = faker.random.number()
     const VERIFY_RATE_LIMIT_SECS = faker.random.number()
+    const CALLBACK_RATE_LIMIT_SECS = faker.random.number()
     const CALLBACK_QUEUE_URL = faker.lorem.word()
     const ASSETS_BUCKET = faker.lorem.word()
     const METRICS_CONFIG = JSON.stringify(metricsConfig)
@@ -94,7 +95,8 @@ describe('configuration', () => {
       VERIFY_RATE_LIMIT_SECS,
       CALLBACK_QUEUE_URL,
       ASSETS_BUCKET,
-      METRICS_CONFIG
+      METRICS_CONFIG,
+      CALLBACK_RATE_LIMIT_SECS
     })
 
     const config = await getConfig()
@@ -134,7 +136,8 @@ describe('configuration', () => {
       encryptKey: ENCRYPT_KEY,
       tokenLifetime: TOKEN_LIFETIME_MINS,
       verifyRateLimit: VERIFY_RATE_LIMIT_SECS,
-      jwtSecret: JWT_SECRET
+      jwtSecret: JWT_SECRET,
+      callbackRateLimitSeconds: CALLBACK_RATE_LIMIT_SECS
     })
 
     expect(config.exposures).toEqual({

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -64,6 +64,7 @@ describe('configuration', () => {
     const UPLOAD_TOKEN_LIFETIME_MINS = faker.random.number()
     const VERIFY_RATE_LIMIT_SECS = faker.random.number()
     const CALLBACK_RATE_LIMIT_SECS = faker.random.number()
+    const CALLBACK_RATE_LIMIT_REQUEST_COUNT = faker.random.number()
     const CALLBACK_QUEUE_URL = faker.lorem.word()
     const ASSETS_BUCKET = faker.lorem.word()
     const METRICS_CONFIG = JSON.stringify(metricsConfig)
@@ -96,7 +97,8 @@ describe('configuration', () => {
       CALLBACK_QUEUE_URL,
       ASSETS_BUCKET,
       METRICS_CONFIG,
-      CALLBACK_RATE_LIMIT_SECS
+      CALLBACK_RATE_LIMIT_SECS,
+      CALLBACK_RATE_LIMIT_REQUEST_COUNT
     })
 
     const config = await getConfig()
@@ -137,7 +139,8 @@ describe('configuration', () => {
       tokenLifetime: TOKEN_LIFETIME_MINS,
       verifyRateLimit: VERIFY_RATE_LIMIT_SECS,
       jwtSecret: JWT_SECRET,
-      callbackRateLimitSeconds: CALLBACK_RATE_LIMIT_SECS
+      callbackRateLimitSeconds: CALLBACK_RATE_LIMIT_SECS,
+      callbackRateLimitRequestCount: CALLBACK_RATE_LIMIT_REQUEST_COUNT
     })
 
     expect(config.exposures).toEqual({

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -204,15 +204,27 @@ async function getConfig() {
     config.security.verifyRateLimit = Number(
       await getParameter('security_verify_rate_limit_secs')
     )
-    config.security.callbackRateLimitSeconds = Number(
-      await getOptionalParameter('security_callback_rate_limit_secs')
+
+    // Read the callback rate limit parameters. Due to backward compatibility
+    // it is perfectly reasonable for the value of security_callback_rate_limit_secs
+    // to be undefined/null and in that case we do not want to call Number(...)
+    // on it. That's why we do this extra check
+    const callbackRateLimitSecsParameter = await getOptionalParameter(
+      'security_callback_rate_limit_secs',
+      null
     )
+    if (callbackRateLimitSecsParameter != null) {
+      config.security.callbackRateLimitSeconds = Number(
+        callbackRateLimitSecsParameter
+      )
+    }
     config.security.callbackRateLimitRequestCount = Number(
       await getOptionalParameter(
         'security_callback_rate_limit_request_count',
         1
       )
     )
+
     config.exposures.defaultRegion = await getParameter('default_region')
     config.aws.assetsBucket = await getParameter('s3_assets_bucket')
     config.aws.callbackQueueUrl = await getParameter('callback_url')

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -37,7 +37,11 @@ async function getConfig() {
       .prop('CODE_LIFETIME_MINS', S.number())
       .prop('UPLOAD_TOKEN_LIFETIME_MINS', S.number())
       .prop('VERIFY_RATE_LIMIT_SECS', S.number())
-      .prop('CALLBACK_RATE_LIMIT_SECS', S.number())
+      .prop('CALLBACK_RATE_LIMIT_SECS', S.anyOf([S.number(), S.null()]))
+      .prop(
+        'CALLBACK_RATE_LIMIT_REQUEST_COUNT',
+        S.anyOf([S.number(), S.null()])
+      )
       .prop('DEVICE_CHECK_KEY_ID', S.string())
       .prop('DEVICE_CHECK_KEY', S.string())
       .prop('DEVICE_CHECK_TEAM_ID', S.string())
@@ -112,7 +116,8 @@ async function getConfig() {
       jwtSecret: env.JWT_SECRET,
       metricsRateLimit: env.METRICS_RATE_LIMIT_SECS,
       verifyRateLimit: env.VERIFY_RATE_LIMIT_SECS,
-      callbackRateLimitSeconds: env.CALLBACK_RATE_LIMIT_SECS
+      callbackRateLimitSeconds: env.CALLBACK_RATE_LIMIT_SECS,
+      callbackRateLimitRequestCount: env.CALLBACK_RATE_LIMIT_REQUEST_COUNT
     },
     exposures: {
       defaultRegion: env.DEFAULT_REGION,
@@ -152,7 +157,7 @@ async function getConfig() {
       return response.Parameter.Value
     }
 
-    const getOptionalParameter = async id => {
+    const getOptionalParameter = async (id, defaultValue = undefined) => {
       const value = await ssm
         .getParameter({ Name: `${env.CONFIG_VAR_PREFIX}${id}` })
         .promise()
@@ -161,7 +166,7 @@ async function getConfig() {
         })
         // eslint-disable-next-line handle-callback-err
         .catch(error => {
-          return undefined
+          return defaultValue
         })
 
       return value
@@ -201,6 +206,12 @@ async function getConfig() {
     )
     config.security.callbackRateLimitSeconds = Number(
       await getOptionalParameter('security_callback_rate_limit_secs')
+    )
+    config.security.callbackRateLimitRequestCount = Number(
+      await getOptionalParameter(
+        'security_callback_rate_limit_request_count',
+        1
+      )
     )
     config.exposures.defaultRegion = await getParameter('default_region')
     config.aws.assetsBucket = await getParameter('s3_assets_bucket')

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -37,6 +37,7 @@ async function getConfig() {
       .prop('CODE_LIFETIME_MINS', S.number())
       .prop('UPLOAD_TOKEN_LIFETIME_MINS', S.number())
       .prop('VERIFY_RATE_LIMIT_SECS', S.number())
+      .prop('CALLBACK_RATE_LIMIT_SECS', S.number())
       .prop('DEVICE_CHECK_KEY_ID', S.string())
       .prop('DEVICE_CHECK_KEY', S.string())
       .prop('DEVICE_CHECK_TEAM_ID', S.string())
@@ -110,7 +111,8 @@ async function getConfig() {
       tokenLifetime: env.TOKEN_LIFETIME_MINS,
       jwtSecret: env.JWT_SECRET,
       metricsRateLimit: env.METRICS_RATE_LIMIT_SECS,
-      verifyRateLimit: env.VERIFY_RATE_LIMIT_SECS
+      verifyRateLimit: env.VERIFY_RATE_LIMIT_SECS,
+      callbackRateLimitSeconds: env.CALLBACK_RATE_LIMIT_SECS
     },
     exposures: {
       defaultRegion: env.DEFAULT_REGION,
@@ -150,6 +152,21 @@ async function getConfig() {
       return response.Parameter.Value
     }
 
+    const getOptionalParameter = async id => {
+      const value = await ssm
+        .getParameter({ Name: `${env.CONFIG_VAR_PREFIX}${id}` })
+        .promise()
+        .then(response => {
+          return response.Parameter.Value
+        })
+        // eslint-disable-next-line handle-callback-err
+        .catch(error => {
+          return undefined
+        })
+
+      return value
+    }
+
     const getSecret = async id => {
       const response = await secretsManager
         .getSecretValue({ SecretId: `${env.CONFIG_VAR_PREFIX}${id}` })
@@ -181,6 +198,9 @@ async function getConfig() {
     )
     config.security.verifyRateLimit = Number(
       await getParameter('security_verify_rate_limit_secs')
+    )
+    config.security.callbackRateLimitSeconds = Number(
+      await getOptionalParameter('security_callback_rate_limit_secs')
     )
     config.exposures.defaultRegion = await getParameter('default_region')
     config.aws.assetsBucket = await getParameter('s3_assets_bucket')

--- a/lib/routes/callback/callback-ratelimit.test.js
+++ b/lib/routes/callback/callback-ratelimit.test.js
@@ -19,6 +19,7 @@ describe('callback routes', () => {
   beforeAll(async () => {
     options = await getConfig()
     options.security.callbackRateLimitSeconds = 5
+    options.security.callbackRateLimitRequestCount = 2
 
     server = require('fastify')()
     server.register(require('.'), options)
@@ -94,7 +95,7 @@ describe('callback routes', () => {
     const mockUpdate = jest.fn(query => {
       if (
         query.text.includes(
-          'WHERE id = $1 AND (last_callback IS NULL OR last_callback <= last_callback::timestamp - $2::INTERVAL)'
+          'WHEN last_callback IS NULL OR last_callback <= CURRENT_TIMESTAMP'
         )
       ) {
         return { rowCount: 1 }

--- a/lib/routes/callback/callback-ratelimit.test.js
+++ b/lib/routes/callback/callback-ratelimit.test.js
@@ -50,7 +50,10 @@ describe('callback routes', () => {
         )}`
       },
       body: {
-        mobile: `+${faker.random.number({ min: 1000000, max: 100000000 })}`,
+        mobile: `+${faker.random.number({
+          min: 10000000000,
+          max: 19999999999
+        })}`,
         closeContactDate: new Date().getTime()
       }
     })
@@ -75,7 +78,10 @@ describe('callback routes', () => {
         )}`
       },
       body: {
-        mobile: `+${faker.random.number({ min: 1000000, max: 100000000 })}`,
+        mobile: `+${faker.random.number({
+          min: 10000000000,
+          max: 19999999999
+        })}`,
         closeContactDate: new Date().getTime()
       }
     })
@@ -109,7 +115,10 @@ describe('callback routes', () => {
         )}`
       },
       body: {
-        mobile: `+${faker.random.number({ min: 1000000, max: 100000000 })}`,
+        mobile: `+${faker.random.number({
+          min: 10000000000,
+          max: 19999999999
+        })}`,
         closeContactDate: new Date().getTime()
       }
     })

--- a/lib/routes/callback/callback-ratelimit.test.js
+++ b/lib/routes/callback/callback-ratelimit.test.js
@@ -18,6 +18,7 @@ describe('callback routes', () => {
 
   beforeAll(async () => {
     options = await getConfig()
+    options.security.callbackRateLimitSeconds = 5
 
     server = require('fastify')()
     server.register(require('.'), options)
@@ -59,7 +60,7 @@ describe('callback routes', () => {
     expect(response.statusCode).toEqual(204)
   })
 
-  it('should fail when already requested callback', async () => {
+  it('should fail when already requested callback within rate limit', async () => {
     const mockUpdate = jest.fn().mockResolvedValue({ rowCount: 0 })
 
     server.pg.write.query = mockUpdate
@@ -83,9 +84,13 @@ describe('callback routes', () => {
     expect(response.statusCode).toEqual(429)
   })
 
-  it('should call database with no rate limit check', async () => {
+  it('should call database with rate limit check', async () => {
     const mockUpdate = jest.fn(query => {
-      if (query.text.includes('WHERE id = $1 AND last_callback IS NULL')) {
+      if (
+        query.text.includes(
+          'WHERE id = $1 AND (last_callback IS NULL OR last_callback <= last_callback::timestamp - $2::INTERVAL)'
+        )
+      ) {
         return { rowCount: 1 }
       } else {
         return { rowCount: 0 }

--- a/lib/routes/callback/callback.test.js
+++ b/lib/routes/callback/callback.test.js
@@ -49,7 +49,10 @@ describe('callback routes', () => {
         )}`
       },
       body: {
-        mobile: `+${faker.random.number({ min: 1000000, max: 100000000 })}`,
+        mobile: `+${faker.random.number({
+          min: 10000000000,
+          max: 19999999999
+        })}`,
         closeContactDate: new Date().getTime()
       }
     })
@@ -74,7 +77,10 @@ describe('callback routes', () => {
         )}`
       },
       body: {
-        mobile: `+${faker.random.number({ min: 1000000, max: 100000000 })}`,
+        mobile: `+${faker.random.number({
+          min: 10000000000,
+          max: 19999999999
+        })}`,
         closeContactDate: new Date().getTime()
       }
     })
@@ -104,7 +110,10 @@ describe('callback routes', () => {
         )}`
       },
       body: {
-        mobile: `+${faker.random.number({ min: 1000000, max: 100000000 })}`,
+        mobile: `+${faker.random.number({
+          min: 10000000000,
+          max: 19999999999
+        })}`,
         closeContactDate: new Date().getTime()
       }
     })

--- a/lib/routes/callback/callback.test.js
+++ b/lib/routes/callback/callback.test.js
@@ -122,4 +122,59 @@ describe('callback routes', () => {
     expect(mockSend).toHaveBeenCalledTimes(1)
     expect(response.statusCode).toEqual(204)
   })
+
+  it('should fail with invalid phone numbers', async () => {
+    const mockUpdate = jest.fn().mockResolvedValue({ rowCount: 1 })
+
+    server.pg.write.query = mockUpdate
+
+    const makeCall = async phoneNumber => {
+      return server.inject({
+        method: 'POST',
+        url: '/callback',
+        headers: {
+          Authorization: `Bearer ${jwt.sign(
+            { id: faker.lorem.word() },
+            options.security.jwtSecret
+          )}`
+        },
+        body: {
+          mobile: phoneNumber,
+          closeContactDate: new Date().getTime()
+        }
+      })
+    }
+
+    expect((await makeCall('123')).statusCode).toEqual(400)
+    expect((await makeCall('+1234567890')).statusCode).toEqual(400)
+    expect((await makeCall('++1234567890')).statusCode).toEqual(400)
+    expect((await makeCall('1234567')).statusCode).toEqual(400)
+  })
+
+  it('should pass with valid phone numbers', async () => {
+    const mockUpdate = jest.fn().mockResolvedValue({ rowCount: 1 })
+
+    server.pg.write.query = mockUpdate
+
+    const makeCall = async phoneNumber => {
+      return server.inject({
+        method: 'POST',
+        url: '/callback',
+        headers: {
+          Authorization: `Bearer ${jwt.sign(
+            { id: faker.lorem.word() },
+            options.security.jwtSecret
+          )}`
+        },
+        body: {
+          mobile: phoneNumber,
+          closeContactDate: new Date().getTime()
+        }
+      })
+    }
+
+    expect((await makeCall('1234567890')).statusCode).toEqual(204)
+    expect((await makeCall('11234567890')).statusCode).toEqual(204)
+    expect((await makeCall('+11234567890')).statusCode).toEqual(204)
+  })
 })

--- a/lib/routes/callback/index.js
+++ b/lib/routes/callback/index.js
@@ -28,7 +28,29 @@ const {
  * There are three rate limit modes, depending on configured settings:
  *  CALLBACK_RATE_LIMIT_SECS is not set: a user is allowed to request a single callback, ever
  *  CALLBACK_RATE_LIMIT_SECS == 0: a user is allowed to request N callback requests with no rate limiting
- *  CALLBACK_RATE_LIMIT_SECS > 0: a user can request subsequent callbacks after # of seconds between each
+ *  CALLBACK_RATE_LIMIT_SECS > 0: callback requests are rate limited in the following ways
+ *    CALLBACK_RATE_LIMIT_REQUEST_COUNT == undefined or 1: a user is allowed to request a new callback after CALLBACK_RATE_LIMIT_SECS has passed
+ *    CALLBACK_RATE_LIMIT_REQUEST_COUNT > 1: a user is able to request up to CALLBACK_RATE_LIMIT_REQUEST_COUNT requests within CALLBACK_RATE_LIMIT_SECS
+ *
+ * If rate limiting is in play then the value of CALLBACK_RATE_LIMIT_REQUEST_COUNT will be taken into account. This
+ * value allows for a specific number of additional requests within a rate limit period. This exists to allow users to
+ * "update" an incorrectly entered phone # up to CALLBACK_RATE_LIMIT_REQUEST_COUNT times before the rate limit blocks
+ * further calls.
+ *
+ * Example 1:
+ *  CALLBACK_RATE_LIMIT_SECS = 60
+ *  CALLBACK_RATE_LIMIT_REQUEST_COUNT = 1
+ *  The user must wait 60 seconds before submitting a 2nd callback request
+ *
+ * Example 2:
+ *  CALLBACK_RATE_LIMIT_SECS = 60
+ *  CALLBACK_RATE_LIMIT_REQUEST_COUNT = 2
+ *  The user can submit 2 callbacks before the rate limit is put into effect
+ *
+ * Example 3:
+ *  CALLBACK_RATE_LIMIT_SECS = 60
+ *  CALLBACK_RATE_LIMIT_REQUEST_COUNT = 5
+ *  The user can submit 5 callbacks before the rate limit is put into effect
  *
  * All requests go through authentication which means both the user and device will be verified. This
  * process will prevent random people from submitting callback requests. Theoretically, only the app
@@ -36,8 +58,7 @@ const {
  *
  * Responses:
  *  204: The callback request was successfully accepted and written to the database
- *  429: User has already requested a callback, and depending on the region rules, there is an existing
- *    unfulfilled callback for the user
+ *  429: User has already requested a callback within the configured rate limit
  */
 async function callback(server, options, done) {
   if (options.routes.callback) {
@@ -74,13 +95,19 @@ async function callback(server, options, done) {
 
         // eslint-disable-next-line no-useless-escape
         mobile = mobile.replace(/[^0-9\+]/g, '')
-        const { callbackRateLimitSeconds: rateLimitSeconds } = options.security
+        const {
+          callbackRateLimitSeconds: rateLimitSeconds,
+          callbackRateLimitRequestCount: rateLimitRequestCount
+        } = options.security
+
         const query =
           rateLimitSeconds == null || rateLimitSeconds < 0
             ? registerOnetimeCallback({ registrationId: id })
             : registerRateLimitedCallback({
                 registrationId: id,
-                rateLimitSeconds
+                rateLimitSeconds: rateLimitSeconds,
+                rateLimitRequestCount:
+                  rateLimitRequestCount == null ? 0 : rateLimitRequestCount
               })
 
         const { rowCount } = await server.pg.write.query(query)

--- a/lib/routes/callback/index.js
+++ b/lib/routes/callback/index.js
@@ -1,7 +1,7 @@
 const fp = require('fastify-plugin')
 const schema = require('./schema')
 const { SQS } = require('aws-sdk')
-const { TooManyRequests } = require('http-errors')
+const { BadRequest, TooManyRequests } = require('http-errors')
 const { metricsInsert } = require('../metrics/query')
 const {
   registerOnetimeCallback,
@@ -53,8 +53,14 @@ async function callback(server, options, done) {
       schema: schema.callback,
       handler: async (request, response) => {
         const { id } = request.authenticate()
-        const { closeContactDate, mobile, payload } = request.body
-
+        let { closeContactDate, mobile, payload } = request.body
+        const phoneRegex = new RegExp('(^|[\\s])(\\+?\\d{1,3}[\\s-\\.]?)?' +
+            '\\(?\\d{3}\\)?[\\s.-]*\\d{3}\\s*[\\s.-]*\\s*\\d{4}' + 
+            '(\\s*x\\s*\\d+)?(\\s|$)', 'g');
+        if (!mobile.match(phoneRegex)) {
+            throw new BadRequest('Supplied an incorrectly formatted phone number.');
+        }
+        mobile = mobile.replace(/[^0-9\+]/g, '')
         const { callbackRateLimitSeconds: rateLimitSeconds } = options.security
         const query =
           rateLimitSeconds == null || rateLimitSeconds < 0

--- a/lib/routes/callback/index.js
+++ b/lib/routes/callback/index.js
@@ -61,7 +61,26 @@ const {
  *  429: User has already requested a callback within the configured rate limit
  */
 async function callback(server, options, done) {
-  if (options.routes.callback) {
+  if (!options.routes.callback) {
+    console.log('Callback Endpoint: Off')
+  } else {
+    console.log('Callback Endpoint: On')
+    const {
+      callbackRateLimitSeconds: rateLimitSeconds,
+      callbackRateLimitRequestCount: rateLimitRequestCount
+    } = options.security
+    if (rateLimitSeconds == null) {
+      console.log(
+        'Callback Rate Limit: Off - users may only send a single callback request'
+      )
+    } else {
+      console.log(
+        `Callback Rate Limit: On - users may send ${
+          rateLimitRequestCount == null ? 1 : rateLimitRequestCount
+        } callback requests every ${rateLimitSeconds} seconds`
+      )
+    }
+
     const sqs = new SQS({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,

--- a/lib/routes/callback/index.js
+++ b/lib/routes/callback/index.js
@@ -47,6 +47,17 @@ async function callback(server, options, done) {
       region: process.env.AWS_REGION
     })
 
+    const validatePhone = mobile => {
+      const phoneRegex = new RegExp(
+        '(^|[\\s])(\\+?\\d{1,3}[\\s-\\.]?)?' +
+          '\\(?\\d{3}\\)?[\\s.-]*\\d{3}\\s*[\\s.-]*\\s*\\d{4}' +
+          '(\\s*x\\s*\\d+)?(\\s|$)',
+        'g'
+      )
+
+      return mobile.match(phoneRegex)
+    }
+
     server.route({
       method: 'POST',
       url: '/callback',
@@ -54,12 +65,14 @@ async function callback(server, options, done) {
       handler: async (request, response) => {
         const { id } = request.authenticate()
         let { closeContactDate, mobile, payload } = request.body
-        const phoneRegex = new RegExp('(^|[\\s])(\\+?\\d{1,3}[\\s-\\.]?)?' +
-            '\\(?\\d{3}\\)?[\\s.-]*\\d{3}\\s*[\\s.-]*\\s*\\d{4}' + 
-            '(\\s*x\\s*\\d+)?(\\s|$)', 'g');
-        if (!mobile.match(phoneRegex)) {
-            throw new BadRequest('Supplied an incorrectly formatted phone number.');
+
+        if (!validatePhone(mobile)) {
+          throw new BadRequest(
+            'Supplied an incorrectly formatted phone number.'
+          )
         }
+
+        // eslint-disable-next-line no-useless-escape
         mobile = mobile.replace(/[^0-9\+]/g, '')
         const { callbackRateLimitSeconds: rateLimitSeconds } = options.security
         const query =

--- a/lib/routes/callback/index.js
+++ b/lib/routes/callback/index.js
@@ -3,7 +3,10 @@ const schema = require('./schema')
 const { SQS } = require('aws-sdk')
 const { TooManyRequests } = require('http-errors')
 const { metricsInsert } = require('../metrics/query')
-const { registerUpdate } = require('./query')
+const {
+  registerOnetimeCallback,
+  registerRateLimitedCallback
+} = require('./query')
 
 /**
  * Allows users to request a callback from a Contact Tracer. If accepted, the request is added to the
@@ -22,14 +25,10 @@ const { registerUpdate } = require('./query')
  * Users are identified by the 'id' in the claims of the request Authorization JWT header. The id value
  * comes from the registration that occurred when the user installed the application.
  *
- * When the request comes in the user's registration record will be updated setting the last_callback
- * column to the current timestamp if and only if the last_callback column is empty. This prevents the
- * same user from entering multiple callback requests.
- *
- * Users will be allowed to request additional callbacks if and only if some other process clears the
- * last_callback cell in the user's record. It will be up to each region to decide if they want to
- * allow subsequent callback requests. If they choose to support that then clearing the last_callback
- * cell will allow a subsequent callback request from the user.
+ * There are three rate limit modes, depending on configured settings:
+ *  CALLBACK_RATE_LIMIT_SECS is not set: a user is allowed to request a single callback, ever
+ *  CALLBACK_RATE_LIMIT_SECS == 0: a user is allowed to request N callback requests with no rate limiting
+ *  CALLBACK_RATE_LIMIT_SECS > 0: a user can request subsequent callbacks after # of seconds between each
  *
  * All requests go through authentication which means both the user and device will be verified. This
  * process will prevent random people from submitting callback requests. Theoretically, only the app
@@ -55,7 +54,17 @@ async function callback(server, options, done) {
       handler: async (request, response) => {
         const { id } = request.authenticate()
         const { closeContactDate, mobile, payload } = request.body
-        const { rowCount } = await server.pg.write.query(registerUpdate({ id }))
+
+        const { callbackRateLimitSeconds: rateLimitSeconds } = options.security
+        const query =
+          rateLimitSeconds == null || rateLimitSeconds < 0
+            ? registerOnetimeCallback({ registrationId: id })
+            : registerRateLimitedCallback({
+                registrationId: id,
+                rateLimitSeconds
+              })
+
+        const { rowCount } = await server.pg.write.query(query)
 
         if (rowCount === 0) {
           throw new TooManyRequests()

--- a/lib/routes/callback/query.js
+++ b/lib/routes/callback/query.js
@@ -14,16 +14,37 @@ const registerOnetimeCallback = ({ registrationId }) =>
       RETURNING id`
 
 /**
- * If the registrationId has not requested a callback within the last rateLimitSeconds period then
- * the last_callback cell is updated with the current timestamp.
+ * If the registrationId has not requested a callback within the last rateLimitSeconds period, or
+ * they have but they haven't requested more than rateLimitRequestCount then the registration record
+ * is updated as follows:
+ *  last_callback = CURRENT_TIMESTAMP
+ *  callback_rate_count is set to 1 if not within rate limit, or incremented if within rate limit
+ *  callback_request_total is incremented
  *
  * Returns an object of { rowCount } where rowCount is 0 if no update was made or 1 if an
  * update was made.
  */
-const registerRateLimitedCallback = ({ registrationId, rateLimitSeconds }) =>
-  SQL`UPDATE registrations
-      SET last_callback = CURRENT_TIMESTAMP
-      WHERE id = ${registrationId} AND (last_callback IS NULL OR last_callback <= last_callback::timestamp - ${`${rateLimitSeconds} secs`}::INTERVAL)
+const registerRateLimitedCallback = ({
+  registrationId,
+  rateLimitSeconds,
+  rateLimitRequestCount
+}) =>
+  SQL`UPDATE  registrations
+      SET     last_callback = CURRENT_TIMESTAMP,
+              callback_rate_count = CASE
+                WHEN last_callback IS NULL OR last_callback <= CURRENT_TIMESTAMP - ${`${rateLimitSeconds} secs`}::INTERVAL THEN 1
+                WHEN callback_rate_count < ${rateLimitRequestCount} THEN callback_rate_count + 1
+                ELSE callback_rate_count
+              END,
+              callback_request_total = CASE
+                WHEN callback_request_total IS NULL THEN 1
+                ELSE callback_request_total + 1
+               END
+      WHERE   id = ${registrationId}
+        AND   (    last_callback IS NULL 
+                OR last_callback <= CURRENT_TIMESTAMP - ${`${rateLimitSeconds} secs`}::INTERVAL
+                OR (last_callback > CURRENT_TIMESTAMP - ${`${rateLimitSeconds} secs`}::INTERVAL AND callback_rate_count < ${rateLimitRequestCount})
+              )
       RETURNING id`
 
 module.exports = {

--- a/lib/routes/callback/query.js
+++ b/lib/routes/callback/query.js
@@ -1,16 +1,32 @@
 const SQL = require('@nearform/sql')
 
 /**
- * If the id has not already requested a callback then the last_callback cell is updated with the
+ * If the registrationId has not already requested a callback then the last_callback cell is updated with the
  * current timestamp.
  *
  * Returns an object of { rowCount } where rowCount is 0 if no update was made or 1 if an
  * update was made.
  */
-const registerUpdate = ({ id }) =>
+const registerOnetimeCallback = ({ registrationId }) =>
   SQL`UPDATE registrations
       SET last_callback = CURRENT_TIMESTAMP
-      WHERE id = ${id} AND last_callback IS NULL
+      WHERE id = ${registrationId} AND last_callback IS NULL
       RETURNING id`
 
-module.exports = { registerUpdate }
+/**
+ * If the registrationId has not requested a callback within the last rateLimitSeconds period then
+ * the last_callback cell is updated with the current timestamp.
+ *
+ * Returns an object of { rowCount } where rowCount is 0 if no update was made or 1 if an
+ * update was made.
+ */
+const registerRateLimitedCallback = ({ registrationId, rateLimitSeconds }) =>
+  SQL`UPDATE registrations
+      SET last_callback = CURRENT_TIMESTAMP
+      WHERE id = ${registrationId} AND (last_callback IS NULL OR last_callback <= last_callback::timestamp - ${`${rateLimitSeconds} secs`}::INTERVAL)
+      RETURNING id`
+
+module.exports = {
+  registerOnetimeCallback,
+  registerRateLimitedCallback
+}

--- a/migrations/003.do.sql
+++ b/migrations/003.do.sql
@@ -1,0 +1,2 @@
+ALTER TABLE registrations ADD COLUMN IF NOT EXISTS callback_rate_count INTEGER NULL;
+ALTER TABLE registrations ADD COLUMN IF NOT EXISTS callback_request_total INTEGER NULL;


### PR DESCRIPTION
If config setting `CALLBACK_RATE_LIMIT_SECS` or AWS value `security_callback_rate_limit_secs` is set to 0 or greater then subsequent callback requests will be allowed after that defined period. The value is in seconds.