### PR TITLE
No longer adds the user registration id to the callback message

### DIFF
--- a/lib/routes/callback/index.js
+++ b/lib/routes/callback/index.js
@@ -138,7 +138,6 @@ async function callback(server, options, done) {
         const body = {
           closeContactDate,
           failedAttempts: 0,
-          id,
           mobile,
           payload
         }


### PR DESCRIPTION
The ID is not being used by anything and is not necessary in the message queue. By removing it we close a potential PII issue.