### PR TITLE
Load RDS root CA bundle from S3

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,4 +1,5 @@
 const envSchema = require('env-schema')
+const fetch = require('node-fetch')
 const S = require('fluent-schema')
 const AWS = require('aws-sdk')
 const { version } = require('../../package.json')
@@ -236,8 +237,13 @@ async function getConfig() {
     config.pgPlugin.config.database = await getParameter('db_database')
 
     if (/true/i.test(await getParameter('db_ssl'))) {
+      const certResponse = await fetch(
+        'https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem'
+      )
+      const certBody = await certResponse.text()
+
       config.pgPlugin.config.ssl = {
-        ca: [rdsSecret.ca],
+        ca: [certBody],
         rejectUnauthorized: true
       }
     }


### PR DESCRIPTION
Load RDS root CA from public URL instead of including in all `rds` secrets