### PR TITLE
Additional error information when device verification fails

### DIFF
--- a/lib/plugins/verify/index.js
+++ b/lib/plugins/verify/index.js
@@ -4,54 +4,90 @@ const jwt = require('jsonwebtoken')
 const SQL = require('@nearform/sql')
 const { pki } = require('node-forge')
 const { v4: uuidv4 } = require('uuid')
-const { BadRequest } = require('http-errors')
+const { BadRequest, InternalServerError } = require('http-errors')
 const { JWS } = require('node-jose')
 const { differenceInMinutes } = require('date-fns')
 
 async function verify(server, options) {
+  const throwError = (code, message) => {
+    const error =
+      code >= 200 ? new InternalServerError(message) : new BadRequest(message)
+
+    error.code = code
+
+    throw error
+  }
+
   server.decorateRequest('verify', async function(nonce) {
+    const { deviceVerification, isProduction } = options
     const {
       deviceVerificationPayload,
       platform,
       timestamp = Date.now()
     } = this.body
-    const { deviceVerification, isProduction } = options
 
-    if (platform === 'test') {
-      try {
-        const { id } = server.jwt.verify(deviceVerificationPayload)
-        const query = SQL`SELECT id FROM tokens WHERE id = ${id} AND type = 'register'`
-        const { rowCount } = await server.pg.read.query(query)
+    try {
+      const serverTimestamp = Date.now()
 
-        if (rowCount === 0) {
-          throw new Error('Invalid token')
-        }
-      } catch (err) {
-        this.log.error(
-          { deviceVerificationPayload, err },
-          'error validating with registration token'
-        )
-        throw new BadRequest('Invalid verification')
-      }
-    } else if (platform === 'android') {
-      try {
-        const { header, payload } = await JWS.createVerify().verify(
-          deviceVerificationPayload,
-          {
-            allowEmbeddedKey: true
+      if (platform === 'test') {
+        try {
+          const { id } = server.jwt.verify(deviceVerificationPayload)
+          const query = SQL`SELECT id FROM tokens WHERE id = ${id} AND type = 'register'`
+          const { rowCount } = await server.pg.read.query(query)
+
+          if (rowCount === 0) {
+            throw new Error()
           }
-        )
+        } catch (err) {
+          throwError(101, 'Invalid token')
+        }
+      } else if (platform === 'android') {
+        let ca, chain, data
 
-        const data = JSON.parse(payload)
-        const ca = pki.createCaStore([
-          pki.certificateFromPem(options.deviceVerification.safetyNetRootCa)
-        ])
-
-        const chain = header.x5c.map(cert => {
-          return pki.certificateFromPem(
-            `-----BEGIN CERTIFICATE-----${cert}-----END CERTIFICATE-----`
+        try {
+          const { header, payload } = await JWS.createVerify().verify(
+            deviceVerificationPayload,
+            {
+              allowEmbeddedKey: true
+            }
           )
-        })
+
+          data = JSON.parse(payload)
+
+          chain = header.x5c.map(cert => {
+            return pki.certificateFromPem(
+              `-----BEGIN CERTIFICATE-----${cert}-----END CERTIFICATE-----`
+            )
+          })
+        } catch (err) {
+          throwError(101, 'Invalid token')
+        }
+
+        try {
+          ca = pki.createCaStore([
+            pki.certificateFromPem(options.deviceVerification.safetyNetRootCa)
+          ])
+        } catch (err) {
+          throwError(200, 'CA missing or invalid')
+        }
+
+        if (
+          pki.verifyCertificateChain(ca, chain) === false ||
+          chain[0].subject.getField('CN').value !== 'attest.android.com'
+        ) {
+          throwError(102, 'Could not verify certificate chain')
+        }
+
+        if (data.nonce !== nonce) {
+          throwError(103, 'Nonce does not match expected value')
+        }
+
+        if (
+          deviceVerification.apkPackageName &&
+          data.apkPackageName !== deviceVerification.apkPackageName
+        ) {
+          throwError(104, 'Package name does not match expected value')
+        }
 
         // The apkDigestSha256 comparison check exists to ensure that the request has come from a known
         // version of the App. This check compares the hash (digest) of the APK file on the phone with the
@@ -63,44 +99,41 @@ async function verify(server, options) {
         // If you'd rather support multiple versions of the app at the same time then the APK check can be
         // turned off by setting the config DEVICE_CHECK_PACKAGE_DIGEST to null.
         if (
-          pki.verifyCertificateChain(ca, chain) === false ||
-          chain[0].subject.getField('CN').value !== 'attest.android.com' ||
-          data.nonce !== nonce ||
-          (deviceVerification.apkPackageName &&
-            data.apkPackageName !== deviceVerification.apkPackageName) ||
-          (deviceVerification.apkDigestSha256 &&
-            data.apkDigestSha256 !== deviceVerification.apkDigestSha256) ||
-          (deviceVerification.apkCertificateDigestSha256 &&
-            JSON.stringify(data.apkCertificateDigestSha256) !==
-              JSON.stringify(deviceVerification.apkCertificateDigestSha256))
+          deviceVerification.apkDigestSha256 &&
+          data.apkDigestSha256 !== deviceVerification.apkDigestSha256
         ) {
-          this.log.error({ data }, 'invalid attestation data')
-          throw new Error('Invalid attestation')
+          throwError(105, 'Package hash does not match expected value')
         }
-      } catch (err) {
-        this.log.error(
-          { deviceVerificationPayload, err },
-          'error validating with SafetyNet'
-        )
-        throw new BadRequest('Invalid verification')
-      }
-    } else if (platform === 'ios') {
-      try {
-        const host = isProduction
-          ? 'api.devicecheck.apple.com'
-          : 'api.development.devicecheck.apple.com'
 
-        const token = jwt.sign({}, deviceVerification.key, {
-          algorithm: 'ES256',
-          keyid: deviceVerification.keyId,
-          issuer: deviceVerification.teamId
-        })
+        if (
+          deviceVerification.apkCertificateDigestSha256 &&
+          JSON.stringify(data.apkCertificateDigestSha256) !==
+            JSON.stringify(deviceVerification.apkCertificateDigestSha256)
+        ) {
+          throwError(
+            106,
+            'Package certificate hash does not match expected value'
+          )
+        }
+      } else if (platform === 'ios') {
+        let response, token
 
-        const serverTimestamp = Date.now()
+        try {
+          token = jwt.sign({}, deviceVerification.key, {
+            algorithm: 'ES256',
+            keyid: deviceVerification.keyId,
+            issuer: deviceVerification.teamId
+          })
+        } catch (err) {
+          throwError(201, 'Credentials are missing or invalid')
+        }
 
-        const response = await fetch(
-          `https://${host}/v1/validate_device_token`,
-          {
+        try {
+          const host = isProduction
+            ? 'api.devicecheck.apple.com'
+            : 'api.development.devicecheck.apple.com'
+
+          response = await fetch(`https://${host}/v1/validate_device_token`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${token}`,
@@ -114,40 +147,31 @@ async function verify(server, options) {
               transaction_id: uuidv4(),
               timestamp: serverTimestamp
             })
-          }
-        )
+          })
+        } catch (err) {
+          throwError(107, 'Error occurred while validating token')
+        }
 
-        if (response.status === 400 && response.statusText === 'Bad Request') {
-          const timeDifferenceInMinutes = Math.abs(
-            differenceInMinutes(serverTimestamp, timestamp)
-          )
+        if (!response.ok) {
           if (
-            timeDifferenceInMinutes >
+            Math.abs(differenceInMinutes(serverTimestamp, timestamp)) >
             deviceVerification.timeDifferenceThresholdMins
           ) {
-            throw new Error('Invalid timestamp')
+            throwError(108, 'Invalid timestamp')
+          } else {
+            throwError(109, 'Invalid verification token')
           }
         }
-
-        if (response.status !== 200) {
-          throw new Error(await response.text())
-        }
-      } catch (err) {
-        this.log.error(
-          { deviceVerificationPayload, err },
-          'error validating with DeviceCheck'
-        )
-
-        const message =
-          err.message === 'Invalid timestamp'
-            ? 'Invalid timestamp'
-            : 'Invalid verification'
-
-        throw new BadRequest(message)
+      } else {
+        throwError(100, 'Unsupported verification method')
       }
-    } else {
-      this.log.error('no verification method provided')
-      throw new BadRequest('Invalid verification')
+    } catch (err) {
+      this.log.error(
+        { deviceVerificationPayload, err, platform },
+        'error verifying device'
+      )
+
+      throw err
     }
   })
 }

--- a/lib/routes/register/index.js
+++ b/lib/routes/register/index.js
@@ -139,7 +139,7 @@ async function register(server, options, done) {
             { expiresIn: `${options.security.tokenLifetime}m` }
           )
         }
-      } catch (error) {
+      } catch (err) {
         await server.pg.write.query(
           metricsInsert({
             event: 'REGISTER_FAIL',
@@ -148,7 +148,7 @@ async function register(server, options, done) {
           })
         )
 
-        throw error
+        throw err
       }
     }
   })


### PR DESCRIPTION
A 1xx error will return a 400 status, 2xx error will return a 500 status. Errors are as follows:

* 100 - Unsupported verification method
* 101 - Error validating JWT, or token invalid (test/android)
* 102 - Could not verify the JWT certificate chain (android)
* 103 - Nonce does not match expected value (android)
* 104 - APK name does not match expected value (android)
* 105 - APK hash does not match expected value (android)
* 106 - APK certificate does not match expected value (android)
* 107 - Network error validating token (ios)
* 108 - Timestamp out of expected threshold (ios)
* 109 - Invalid verification token (ios)
* 200 - SafetyNet CA in config is missing or invalid
* 201 - DeviceCheck credentials in config are missing or invalid