### PR TITLE
Support for EN express

### DIFF
--- a/lib/plugins/jwt/index.js
+++ b/lib/plugins/jwt/index.js
@@ -4,9 +4,9 @@ const { Unauthorized } = require('http-errors')
 async function jwt(server, options) {
   function authenticate() {
     try {
-      const data = server.jwt.verify(
-        this.headers.authorization.replace(/^Bearer /, '')
-      )
+      const resolvedToken =
+        this.headers.authorization || this.headers['x-api-key']
+      const data = server.jwt.verify(resolvedToken.replace(/^Bearer /, ''))
 
       if (data.refresh) {
         throw new Error()

--- a/lib/routes/exposures/exposures.test.js
+++ b/lib/routes/exposures/exposures.test.js
@@ -95,7 +95,7 @@ describe('exposure routes', () => {
     expect(mockWrite).toHaveBeenCalledTimes(3)
     expect(mockRead).toHaveBeenCalledTimes(1)
     expect(response.statusCode).toEqual(200)
-    expect(payload).toEqual({ token: result })
+    expect(payload).toEqual(expect.objectContaining({ token: result }))
   })
 
   it('should fail when user is currently rate limited', async () => {

--- a/lib/routes/exposures/index.js
+++ b/lib/routes/exposures/index.js
@@ -2,7 +2,7 @@ const crypto = require('crypto')
 const fp = require('fastify-plugin')
 const jwt = require('jsonwebtoken')
 const schema = require('./schema')
-const { BadRequest, Forbidden, Gone, TooManyRequests } = require('http-errors')
+const { BadRequest, Forbidden, Gone } = require('http-errors')
 const {
   differenceInDays,
   differenceInMinutes,
@@ -21,6 +21,21 @@ const {
 } = require('./query')
 
 async function exposures(server, options, done) {
+  const createError = (response, statusCode, error, errorCode) => {
+    response.status(statusCode)
+
+    return {
+      error: error,
+      errorCode: errorCode,
+      padding: generatePadding()
+    }
+  }
+
+  const generatePadding = () =>
+    crypto
+      .randomBytes(Math.floor(Math.random() * 1024 + 1024))
+      .toString('base64')
+
   const hash = value => {
     const sha512 = crypto.createHash('sha512')
     const data = sha512.update(value, 'utf8')
@@ -28,7 +43,19 @@ async function exposures(server, options, done) {
     return data.digest('hex')
   }
 
-  const exchangeCodeForToken = async (id, control, code) => {
+  const exchangeCodeForToken = async (
+    response,
+    id,
+    control,
+    code,
+    accept = 'negative'
+  ) => {
+    const testTypes = {
+      confirmed: 0,
+      likely: 1,
+      negative: 2
+    }
+
     const { rowCount: registerRateLimit } = await server.pg.write.query(
       registerUpdate({
         rateLimit: options.security.verifyRateLimit,
@@ -37,7 +64,12 @@ async function exposures(server, options, done) {
     )
 
     if (registerRateLimit === 0) {
-      throw new TooManyRequests()
+      return createError(
+        response,
+        429,
+        'Too many requests',
+        'too_many_requests'
+      )
     }
 
     const { rows: hashRows } = await server.pg.read.query(
@@ -48,16 +80,30 @@ async function exposures(server, options, done) {
     )
 
     if (hashRows.length === 0) {
-      throw new Forbidden()
+      return createError(
+        response,
+        403,
+        'Verification code invalid',
+        'code_invalid'
+      )
     }
 
     const [{ verificationId, createdAt, onsetDate, testType }] = hashRows
+
+    if (testTypes[testType] > testTypes[accept]) {
+      return createError(
+        response,
+        412,
+        'Invalid test type',
+        'invalid_test_type'
+      )
+    }
 
     if (
       differenceInMinutes(new Date(), new Date(createdAt)) >
       options.security.codeLifetime
     ) {
-      throw new Gone()
+      return createError(response, 410, 'Code expired', 'code_expired')
     }
 
     await server.pg.write.query(verificationDelete({ verificationId }))
@@ -108,16 +154,14 @@ async function exposures(server, options, done) {
     method: 'POST',
     url: '/exposures/verify',
     schema: schema.verify,
-    handler: async request => {
+    handler: async (request, response) => {
       const { id } = request.authenticate()
       const { hash } = request.body
 
       const controlHash = hash.substr(0, 128)
       const codeHash = hash.substr(128)
 
-      const { token } = await exchangeCodeForToken(id, controlHash, codeHash)
-
-      return { token }
+      return await exchangeCodeForToken(response, id, controlHash, codeHash)
     }
   })
 
@@ -125,27 +169,40 @@ async function exposures(server, options, done) {
     method: 'POST',
     url: '/verify',
     schema: schema.exchange,
-    handler: async request => {
+    handler: async (request, response) => {
       const { id } = request.authenticate()
-      const { code } = request.body
+      const { accept, code } = request.body
 
+      const resolvedAccept = accept ? accept[accept.length - 1] : 'negative'
       const controlHash = hash(code.substr(0, Math.floor(code.length / 2)))
       const codeHash = hash(code)
 
-      const { onsetDate, testType, token } = await exchangeCodeForToken(
+      const result = await exchangeCodeForToken(
+        response,
         id,
         controlHash,
-        codeHash
+        codeHash,
+        resolvedAccept
       )
 
+      if (result.error) {
+        return result
+      }
+
+      const { onsetDate, testType, token } = result
+
       if (!onsetDate) {
-        throw new Forbidden()
+        return createError(
+          response,
+          400,
+          'Onset date is missing',
+          'missing_date'
+        )
       }
 
       const symptomDate = format(onsetDate, 'yyyy-MM-dd')
 
       return {
-        error: '',
         symptomDate,
         testtype: testType,
         token: jwt.sign({}, options.verify.privateKey, {
@@ -156,7 +213,8 @@ async function exposures(server, options, done) {
           jwtid: token,
           keyid: String(options.verify.keyId),
           subject: `${testType}.${symptomDate}`
-        })
+        }),
+        padding: generatePadding()
       }
     }
   })
@@ -165,7 +223,7 @@ async function exposures(server, options, done) {
     method: 'POST',
     url: '/certificate',
     schema: schema.certificate,
-    handler: async request => {
+    handler: async (request, response) => {
       const { id } = request.authenticate()
       const { ekeyhmac, token } = request.body
 
@@ -179,13 +237,18 @@ async function exposures(server, options, done) {
       )
 
       if (rowCount === 0) {
-        throw new Forbidden()
+        return createError(response, 400, 'Token invalid', 'token_invalid')
       }
 
       const [{ onsetDate, testType }] = rows
 
       if (!onsetDate) {
-        throw new Forbidden()
+        return createError(
+          response,
+          400,
+          'Onset date is missing',
+          'missing_date'
+        )
       }
 
       await server.pg.write.query(
@@ -201,7 +264,6 @@ async function exposures(server, options, done) {
           {
             reportType: testType,
             symptomOnsetInterval: Math.floor(onsetDate.getTime() / 1000 / 600),
-            trisk: [],
             tekmac: ekeyhmac
           },
           options.verify.privateKey,
@@ -213,22 +275,18 @@ async function exposures(server, options, done) {
             keyid: String(options.verify.keyId)
           }
         ),
-        error: ''
+        padding: generatePadding()
       }
     }
   })
 
   const uploadHandler = async request => {
     const { id } = request.authenticate()
-    const padding = crypto
-      .randomBytes(Math.floor(Math.random() * 1024 + 1024))
-      .toString('base64')
 
     if ('x-chaff' in request.headers) {
       return {
         insertedExposures: 0,
-        error: '',
-        padding
+        padding: generatePadding()
       }
     } else {
       const { deviceVerification } = options
@@ -386,8 +444,7 @@ async function exposures(server, options, done) {
 
       return {
         insertedExposures: filteredExposures.length,
-        error: '',
-        padding
+        padding: generatePadding()
       }
     }
   }

--- a/lib/routes/exposures/schema.js
+++ b/lib/routes/exposures/schema.js
@@ -12,12 +12,17 @@ const certificate = {
   response: {
     200: S.object()
       .prop('certificate', S.string().required())
-      .prop('error', S.string().required())
+      .prop('padding', S.string().required())
   }
 }
 
 const exchange = {
-  body: S.object().prop('code', S.string().required()),
+  body: S.object()
+    .prop('code', S.string().required())
+    .prop(
+      'accept',
+      S.array().items(S.string().enum(['confirmed', 'likely', 'negative']))
+    ),
   response: {
     200: S.object()
       .prop(
@@ -28,7 +33,7 @@ const exchange = {
       )
       .prop('symptomDate', S.string().format('date'))
       .prop('token', S.string().required())
-      .prop('error', S.string().required())
+      .prop('padding', S.string().required())
   }
 }
 
@@ -116,7 +121,6 @@ const publish = {
   response: {
     200: S.object()
       .prop('insertedExposures', S.number().required())
-      .prop('error', S.string().required())
       .prop('padding', S.string().required())
   }
 }
@@ -131,12 +135,13 @@ const upload = {
 const verify = {
   body: S.object().prop('hash', S.string().pattern(/[a-z0-9]{256}/)),
   response: {
-    200: S.object().prop(
-      'token',
-      S.string()
-        .format('uuid')
-        .required()
-    )
+    200: S.object()
+      .prop(
+        'token',
+        S.string()
+          .format('uuid')
+          .required()
+      )
   }
 }
 

--- a/lib/routes/exposures/schema.js
+++ b/lib/routes/exposures/schema.js
@@ -135,13 +135,12 @@ const upload = {
 const verify = {
   body: S.object().prop('hash', S.string().pattern(/[a-z0-9]{256}/)),
   response: {
-    200: S.object()
-      .prop(
-        'token',
-        S.string()
-          .format('uuid')
-          .required()
-      )
+    200: S.object().prop(
+      'token',
+      S.string()
+        .format('uuid')
+        .required()
+    )
   }
 }
 

--- a/lib/routes/register/index.js
+++ b/lib/routes/register/index.js
@@ -161,9 +161,10 @@ async function register(server, options, done) {
       let data
 
       try {
-        data = server.jwt.verify(
-          request.headers.authorization.replace(/^Bearer /, '')
-        )
+        const resolvedToken =
+          request.headers.authorization || request.headers['x-api-key']
+
+        data = server.jwt.verify(resolvedToken.replace(/^Bearer /, ''))
 
         if (!data.id || !data.refresh) {
           throw new Error()


### PR DESCRIPTION
Compatibility with current version of https://github.com/google/exposure-notifications-verification-server/blob/main/docs/api.md

* Accept `X-Api-Key` as well as `Authorization: Bearer`
* Add `padding` to all relevant responses
* Handle optional `accept` in request
* Ensure returned errors match (with exceptions, see below)

The status code for an invalid code will be 403, and an expired code will be 410, as the apps using the endpoints expect these status codes to handle these errors. These are the only 2 places our API differs from the reference docs.