### PR TITLE
Properly calculate days since onset date per key

### DIFF
--- a/lib/routes/exposures/index.js
+++ b/lib/routes/exposures/index.js
@@ -367,10 +367,19 @@ async function exposures(server, options, done) {
       if (filteredExposures.length > 0) {
         await server.pg.write.query(
           exposureInsert({
-            daysSinceOnset: resolvedOnsetDate
-              ? differenceInDays(new Date(), resolvedOnsetDate)
-              : 0,
-            exposures: filteredExposures,
+            exposures: filteredExposures.map(exposure => {
+              const startDate = new Date(
+                exposure.rollingStartNumber * 1000 * 600
+              )
+              const daysSinceOnset = resolvedOnsetDate
+                ? differenceInDays(startDate, resolvedOnsetDate)
+                : 0
+
+              return {
+                ...exposure,
+                daysSinceOnset
+              }
+            }),
             regions: resolvedRegions,
             testType: resolvedTestType
           })

--- a/lib/routes/exposures/query.js
+++ b/lib/routes/exposures/query.js
@@ -1,11 +1,17 @@
 const SQL = require('@nearform/sql')
 
-const exposureInsert = ({ daysSinceOnset, exposures, regions, testType }) => {
+const exposureInsert = ({ exposures, regions, testType }) => {
   const query = SQL`INSERT INTO exposures (key_data, rolling_period, rolling_start_number, transmission_risk_level, regions, test_type, days_since_onset) VALUES `
 
   for (const [
     index,
-    { key, rollingPeriod, rollingStartNumber, transmissionRiskLevel }
+    {
+      daysSinceOnset,
+      key,
+      rollingPeriod,
+      rollingStartNumber,
+      transmissionRiskLevel
+    }
   ] of exposures.entries()) {
     query.append(
       SQL`(


### PR DESCRIPTION
Query to fix existing data when deploying:

```sql
UPDATE exposures
SET days_since_onset = (((rolling_start_number * 600) - (EXTRACT(EPOCH FROM created_at) - (days_since_onset * 86400))) / 86400)::INT
WHERE origin IS NULL;
```