### PR TITLE
Allow more flexibility with cors

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -4,6 +4,12 @@ const S = require('fluent-schema')
 const AWS = require('aws-sdk')
 const { version } = require('../../package.json')
 
+function parseCorsParameter(param) {
+  if (param === 'true') return true
+  if (param === 'false') return false
+  return param
+}
+
 async function getConfig() {
   const env = envSchema({
     dotenv: true,
@@ -95,7 +101,7 @@ async function getConfig() {
         }
       }
     },
-    cors: { origin: /true/i.test(env.CORS_ORIGIN) },
+    cors: { origin: parseCorsParameter(env.CORS_ORIGIN) },
     pgPlugin: {
       read: env.DB_READ_HOST,
       write: env.DB_HOST,
@@ -213,7 +219,7 @@ async function getConfig() {
     config.fastify.host = await getParameter('api_host')
     config.fastify.port = Number(await getParameter('api_port'))
     config.fastifyInit.logger.level = await getParameter('log_level')
-    config.cors.origin = /true/i.test(await getParameter('cors_origin'))
+    config.cors.origin = parseCorsParameter(await getParameter('cors_origin'))
     config.security.jwtIssuer = await getParameter('jwt_issuer')
     config.security.refreshTokenExpiry = await getParameter(
       'security_refresh_token_expiry'


### PR DESCRIPTION
This allow cors origin to be other values than `true` or `false`.

This must be merged carefully, as there's a chance it will open up cors on all platform where the `cors_origin` parameter is set to `*` (which prior to this change was translated to `false`)